### PR TITLE
[#3] Automatically install all vcpkg dependencies/include in installer

### DIFF
--- a/cmake/vcpkg_init.cmake
+++ b/cmake/vcpkg_init.cmake
@@ -1,3 +1,9 @@
+# This ensures that all VCPKG dependencies are also installed by `cmake install`
+# and are included in CPack installer.
+# NOTE: it's not ideal as it is an experimental vcpkg feature, but its the
+# cleanest way right now
+set(X_VCPKG_APPLOCAL_DEPS_INSTALL TRUE CACHE BOOL "Install vcpkg dependencies")
+
 # This allows configuring with pre-configured vcpkg via -DCMAKE_TOOLCHAIN_FILE=...
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   file(READ "${CMAKE_SOURCE_DIR}/vcpkg.json" VCPKG_JSON_CONTENT)


### PR DESCRIPTION
This isn't the ideal solution as it relies on experimental feature in
vcpkg, but its the cleanest way that doesn't require listing every
dependency manually. Hopefully this will become default in future
vcpkg versions.