### PR TITLE
[#2] Fix flickering on Pimax devices with Pimax OpenXR runtime

### DIFF
--- a/code/vr/vr_swapchains.h
+++ b/code/vr/vr_swapchains.h
@@ -15,11 +15,11 @@ void VR_GetRecommendedResolution(XrInstance instance, XrSystemId systemId, int* 
 VR_SwapchainInfos VR_CreateSwapchains(XrInstance instance, XrSystemId systemId, XrSession session);
 void VR_DestroySwapchains(VR_SwapchainInfos* swapchains);
 
-void VR_Swapchains_BindFramebuffers(VR_SwapchainInfos* swapchains, uint32_t swapchainImageIndex);
+void VR_Swapchains_BindFramebuffers(VR_SwapchainInfos* swapchains, uint32_t swapchainColorIndex, uint32_t swapchainDepthIndex);
 void VR_Swapchains_BlitXRToMainFbo(VR_SwapchainInfos* swapchains, uint32_t swapchainImageIndex, XrDesktopViewConfiguration viewConfig);
 void VR_Swapchains_BlitXRToVirtualScreen(VR_SwapchainInfos* swapchains, uint32_t swapchainImageIndex);
 
-uint32_t VR_Swapchains_Acquire(VR_SwapchainInfos* swapchains);
+void VR_Swapchains_Acquire(VR_SwapchainInfos* swapchains, uint32_t* colorIndex, uint32_t* depthIndex);
 void VR_Swapchains_Release(VR_SwapchainInfos* swapchains);
 
 #endif


### PR DESCRIPTION
This commit fixes the bug on Pimax devices (e.g. Pimax Vision 8K X) that caused flickering when switching between frames (e.g. correct one, black, correct one, black, correct one, ...).

The problem was in image indexes where Q3VR used to use same index for both color and depth swapchains (actually used the one returned for depth swapchain for both) instead of using separate indices for each. It worked fine in other VR runtimes but it seems that Pimax OpenXR runtime can actually drift on indices used and most likely Q3VR was rendering to a wrong image.