### PR TITLE
Properly save/load graphics settings

### DIFF
--- a/assets/pakQ3VR/ui/ingame_system.menu
+++ b/assets/pakQ3VR/ui/ingame_system.menu
@@ -296,7 +296,7 @@ itemDef {
     		type ITEM_TYPE_MULTI
 		text "Geometric Detail:"
 		cvar "r_lodbias"
-		cvarFloatList { "High" -1 "Medium" 1 "Low" 2 }
+		cvarFloatList { "High" -2 "Medium" -1 "Low" 0 }
 		rect 0 190 256 20
       		textalign ITEM_ALIGN_RIGHT
       		textalignx 133

--- a/assets/pakQ3VR/ui/system.menu
+++ b/assets/pakQ3VR/ui/system.menu
@@ -199,7 +199,7 @@ itemDef {
     		type ITEM_TYPE_MULTI
 		text "Geometric Detail:"
 		cvar "r_lodbias"
-		cvarFloatList { "High" -1 "Medium" 1 "Low" 2 }
+		cvarFloatList { "High" -2 "Medium" -1 "Low" 0 }
 		rect 99 217 256 20
       		textalign ITEM_ALIGN_RIGHT
       		textalignx 128

--- a/code/q3_ui/ui_video.c
+++ b/code/q3_ui/ui_video.c
@@ -665,12 +665,12 @@ static void GraphicsOptions_SetMenuItems( void )
 	}
 
 	int lodbias = trap_Cvar_VariableValue( "r_lodBias" );
-	if (lodbias == -1) {
-		s_graphicsoptions.geometry.curvalue = 2;
-	} else if (lodbias == 1) {
-		s_graphicsoptions.geometry.curvalue = 1;
+	if (lodbias <= -2) {
+		s_graphicsoptions.geometry.curvalue = 2;  // High
+	} else if (lodbias == -1) {
+		s_graphicsoptions.geometry.curvalue = 1;  // Medium
 	} else {
-		s_graphicsoptions.geometry.curvalue = 0;
+		s_graphicsoptions.geometry.curvalue = 0;  // Low
 	}
 
 #if 0

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -3234,14 +3234,14 @@ static void UI_Update(const char *name) {
 		}
 	} else if (Q_stricmp(name, "r_lodbias") == 0) {
 		switch (val) {
+			case -2:
+				trap_Cvar_SetValue( "r_subdivisions", 1 );  // High
+			break;
+			case -1:
+				trap_Cvar_SetValue( "r_subdivisions", 2 );  // Medium
+			break;
 			case 0:
-				trap_Cvar_SetValue( "r_subdivisions", 1 );
-			break;
-			case 1:
-				trap_Cvar_SetValue( "r_subdivisions", 2 );
-			break;
-			case 2:
-				trap_Cvar_SetValue( "r_subdivisions", 4 );
+				trap_Cvar_SetValue( "r_subdivisions", 4 );  // Low
 			break;
 		}
 	} else if (Q_stricmp(name, "ui_glCustom") == 0) {


### PR DESCRIPTION
This is a bug that carried over from the ioq3quest code, where the r_lodbias settings being compared to set the geometric detail options were mismatched with what is set, so the "high" setting would display as "low" on next load.